### PR TITLE
Added way to use vagrant as the backend only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yunity-sockets
 local_settings.make
 swagger-ui
 swagger*.tar.gz
+.vagrant

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ git_url_base = git@github.com:yunity/
 
 # all yunity-* projects
 
-frontend_project_dirs = yunity-webapp-common yunity-webapp yunity-webapp-mobile
+frontend_project_dirs = yunity-webapp-common yunity-webapp-mobile
 backend_project_dirs = yunity-core yunity-sockets
 project_dirs = $(frontend_project_dirs) $(backend_project_dirs)
 
@@ -44,7 +44,7 @@ project_dirs = $(frontend_project_dirs) $(backend_project_dirs)
 setup: setup-backend setup-frontend
 
 setup-backend: setup-core setup-sockets setup-swagger-ui
-setup-frontend: setup-webapp-common setup-webapp setup-webapp-mobile
+setup-frontend: setup-webapp-common setup-webapp-mobile
 
 # update
 #
@@ -64,6 +64,11 @@ update-backend:
 	@git pull
 	@make git-pull-backend setup-backend
 
+update-frontend:
+	@echo && echo "# $@" && echo
+	@git pull
+	@make git-pull-frontend setup-frontend
+
 setup-core: | yunity-core init-db pip-install migrate-db
 
 setup-sockets: | yunity-sockets npm-system-deps
@@ -80,14 +85,19 @@ setup-webapp: | yunity-webapp-common yunity-webapp npm-deps npm-system-deps
 	@cd yunity-webapp && npm-cache install bower --allow-root
 	@rm -rf yunity-webapp/node_modules/yunity-webapp-common
 	@cd yunity-webapp/node_modules && ln -s ../../yunity-webapp-common .
+	#@cd yunity-webapp && $$(npm bin)/webpack
+
+build-webapp:
 	@cd yunity-webapp && $$(npm bin)/webpack
 
 setup-webapp-mobile: | yunity-webapp-common yunity-webapp-mobile npm-deps npm-system-deps
 	@echo && echo "# $@" && echo
 	@cd yunity-webapp-mobile && npm-cache install npm --unsafe-perm
-	@cd yunity-webapp-mobile && npm-cache install bower --allow-root
+	#@cd yunity-webapp-mobile && npm-cache install bower --allow-root
 	@rm -rf yunity-webapp-mobile/node_modules/yunity-webapp-common
 	@cd yunity-webapp-mobile/node_modules && ln -s ../../yunity-webapp-common .
+
+build-webapp-mobile:
 	@cd yunity-webapp-mobile && $$(npm bin)/webpack
 
 # setup-swagger-ui

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,26 @@
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "yunity-backend-1.0"
+
+  config.vm.network "public_network"
+
+  # same port inside and out for these
+  [
+    8000, # django
+    8080, # sockets
+    9080  # sockets admin
+  ].each do |port|
+    config.vm.network :forwarded_port, guest: port, host: port
+  end
+
+  # postgresql
+  config.vm.network :forwarded_port, guest: 5432, host: 15432
+
+  # redis
+  config.vm.network :forwarded_port, guest: 6379, host: 16379
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "1024"
+  end
+
+end

--- a/pm2-backend.json
+++ b/pm2-backend.json
@@ -1,19 +1,6 @@
 {
   "apps": [
     {
-      "name": "proxy",
-      "script": "proxy.js"
-    },
-    {
-      "name": "mobile",
-      "script": "node_modules/.bin/webpack-dev-server",
-      "args": [
-        "--port", "8084",
-        "--inline"
-      ],
-      "cwd": "yunity-webapp-mobile"
-    },
-    {
       "name": "sockets",
       "script": "index.js",
       "args": [

--- a/pm2-frontend.json
+++ b/pm2-frontend.json
@@ -1,0 +1,17 @@
+{
+  "apps": [
+    {
+      "name": "proxy",
+      "script": "proxy.js"
+    },
+    {
+      "name": "mobile",
+      "script": "node_modules/.bin/webpack-dev-server",
+      "args": [
+        "--port", "8084",
+        "--inline"
+      ],
+      "cwd": "yunity-webapp-mobile"
+    }
+  ]
+}

--- a/proxy.js
+++ b/proxy.js
@@ -29,9 +29,10 @@ var proxy = httpProxy.createProxyServer({});
 /* these sites will be shown on the top bar of the admin/dev site */
 
 var sites = [
-  { name: 'web app',            url: WEBAPP_URL },
+  // not working on the app app for now
+  //{ name: 'web app',            url: WEBAPP_URL },
   { name: 'mobile web app',     url: MOBILE_URL },
-  { name: 'swagger',            url: WEBAPP_URL + 'swagger' },
+  { name: 'swagger',            url: MOBILE_URL + 'swagger' },
   { name: 'socket connections', url: SOCKET_CONNECTION_VIEW_URL }
 ];
 
@@ -42,7 +43,8 @@ var sites = [
 
 */
 
-createHttpServerFor(WEBAPP_SERVER).listen(WEBAPP_PORT);
+// removed because we are not working on it right now
+//createHttpServerFor(WEBAPP_SERVER).listen(WEBAPP_PORT);
 
 /*
 


### PR DESCRIPTION
- split pm2.json into pm2-frontend.json and pm2-backend.json
- removed yunity-webapp from most things whilst we're not
  working on it at the moment
- added Vagrantfile to use vagrant image built from
  backend-only branch of yunity-vagrant

So, to run it with this new way:
1. start the frontend: `pm2 start pm2-frontend.json`
2. then to get a backend, either:
   a. local: `pm2 start pm2-backend.json`
   b. vagrant: `vagrant up`

All app ports will be the same for either.
http://localhost:5000 will host the dev page.

For initial setup `make setup-frontend` or `make setup-backend`
For updating use `make update-frontend` or `make update-backend`

For vagrant, to update the app stuff, you can run:
`vagrant ssh -- ./update` and it'll pull the latest backend
code and do anything else needed.

To drop the db and make a new one, you can run:
`vagrant ssh -- ./trash-db`

If you want to update the packages inside the vm, just
do it like normal: `sudo apt-get update && sudo apt-get upgrade`

For vagrant you'll first need the yunity-backend-1.0.box file,
this gets build from the yunity-vagrant repo (backend-only branch),
it is not currently available anywhere online.
